### PR TITLE
Fix OptionType constructor.

### DIFF
--- a/merchantsdk/src/main/java/urn/ebay/apis/eBLBaseComponents/OptionType.java
+++ b/merchantsdk/src/main/java/urn/ebay/apis/eBLBaseComponents/OptionType.java
@@ -89,16 +89,16 @@ public class OptionType{
 		XPath xpath = factory.newXPath();
 		Node childNode = null;
 		NodeList nodeList = null;
-		childNode = (Node) xpath.evaluate("name", node, XPathConstants.NODE);
-		if (childNode != null && !isWhitespaceNode(childNode)) {
-		    this.name = childNode.getTextContent();
+		
+		childNode = (Node) xpath.evaluate("@name", node, XPathConstants.NODE);
+		if (childNode != null) {
+		    this.name = childNode.getNodeValue();
 		}
 	
-		childNode = (Node) xpath.evaluate("value", node, XPathConstants.NODE);
-		if (childNode != null && !isWhitespaceNode(childNode)) {
-		    this.value = childNode.getTextContent();
+		childNode = (Node) xpath.evaluate("@value", node, XPathConstants.NODE);
+		if (childNode != null) {
+		    this.value = childNode.getNodeValue();
 		}
-	
 	}
  
 }


### PR DESCRIPTION
In my testing, the XML response has the name and value as attributes, not child nodes:

    [...]
    <PaymentItem xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:PaymentItemType">
      [...]
      <Options xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:OptionType" value="2" name="Adult tickets"></Options>
      <Options xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:OptionType" value="2" name="Child tickets"></Options>
    </PaymentItem>
    [...]
